### PR TITLE
Allow strobe on any GPIO

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -162,12 +162,14 @@ gen.add("trigger_delay",              double_t, SensorLevels.RECONFIGURE_RUNNING
 
 gen.add("trigger_parameter", 	      int_t,    SensorLevels.RECONFIGURE_RUNNING,    "Trigger mode parameter.  Varies based on mode.",                                      0, -32768, 32767)
 
-gen.add("enable_strobe1", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Whether strobe is sent.", False)
+gen.add("enable_strobe", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Whether strobe is sent.", False)
 
-gen.add("strobe1_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strobe Polarity", 0, edit_method = polarities)
+gen.add("strobe_source", str_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strobe Output",                                                                                   "gpio1",     edit_method = gpio_pins)
 
-gen.add("strobe1_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "The delay between capture and strobe out (in milliseconds).", 0.0, 0.0, 1000.0)
+gen.add("strobe_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strobe Polarity", 0, edit_method = polarities)
 
-gen.add("strobe1_duration", double_t, SensorLevels.RECONFIGURE_RUNNING, "Strobe duration (in milliseconds)", 0.0, 1.0, 1000.0)
+gen.add("strobe_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "The delay between capture and strobe out (in milliseconds).", 0.0, 0.0, 1000.0)
+
+gen.add("strobe_duration", double_t, SensorLevels.RECONFIGURE_RUNNING, "Strobe duration (in milliseconds)", 0.0, 1.0, 1000.0)
 
 exit(gen.generate(PACKAGE, "pointgrey_camera_driver", "PointGrey"))

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -143,7 +143,7 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
       {
       bool temp = config.trigger_polarity;
       retVal &= PointGreyCamera::setExternalTrigger(config.enable_trigger, config.trigger_mode, config.trigger_source, config.trigger_parameter, config.trigger_delay, temp);
-      config.strobe1_polarity = temp;
+      config.strobe_polarity = temp;
       }
       break;
     default:
@@ -151,14 +151,14 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
   }
 
   // Set strobe
-  switch (config.strobe1_polarity)
+  switch (config.strobe_polarity)
   {
     case pointgrey_camera_driver::PointGrey_Low:
     case pointgrey_camera_driver::PointGrey_High:
       {
-      bool temp = config.strobe1_polarity;
-      retVal &= PointGreyCamera::setExternalStrobe(config.enable_strobe1, pointgrey_camera_driver::PointGrey_GPIO1, config.strobe1_duration, config.strobe1_delay, temp);
-      config.strobe1_polarity = temp;
+      bool temp = config.strobe_polarity;
+      retVal &= PointGreyCamera::setExternalStrobe(config.enable_strobe, config.strobe_source, config.strobe_duration, config.strobe_delay, temp);
+      config.strobe_polarity = temp;
       }
       break;
     default:


### PR DESCRIPTION
This PR allows the camera to be configured to use any of the GPIO pins as the strobe pin.