### PR TITLE
Flag for camera info publishing.

### DIFF
--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -160,7 +160,8 @@ private:
     NODELET_DEBUG("Connect callback!");
     boost::mutex::scoped_lock scopedLock(connect_mutex_); // Grab the mutex.  Wait until we're done initializing before letting this function through.
     // Check if we should disconnect (there are 0 subscribers to our data)
-    if(it_pub_.getNumSubscribers() == 0 && pub_->getPublisher().getNumSubscribers() == 0)
+    if( (it_pub_.getNumSubscribers() == 0 && image_pub_.getNumSubscribers() == 0)
+        && pub_->getPublisher().getNumSubscribers() == 0)
     {
       if (pubThread_)
       {
@@ -288,8 +289,16 @@ private:
     // Publish topics using ImageTransport through camera_info_manager (gives cool things like compression)
     it_.reset(new image_transport::ImageTransport(nh));
     image_transport::SubscriberStatusCallback cb = boost::bind(&PointGreyCameraNodelet::connectCb, this);
-    it_pub_ = it_->advertiseCamera("image_raw", 5, cb, cb);
-    image_pub_ = it_->advertise("image_raw", 5, cb, cb);
+
+    if(publish_camera_info_)
+    {
+      it_pub_ = it_->advertiseCamera("image_raw", 5, cb, cb);
+    }
+    else
+    {
+      image_pub_ = it_->advertise("image_raw", 5, cb, cb);
+    }
+
     // Set up diagnostics
     updater_.setHardwareID("pointgrey_camera " + cinfo_name.str());
 


### PR DESCRIPTION
Added flag to enable/disable camera info publishing and required publisher for image transport.

This is needed so we can use other sources of camera calibration parameters like Kalibr. 