### PR TITLE
Reverted to Spinnaker Version 1.2.0.16

### DIFF
--- a/pointgrey_camera_driver/cmake/download_spinnaker
+++ b/pointgrey_camera_driver/cmake/download_spinnaker
@@ -44,13 +44,13 @@ LOGIN_DATA = {
 
 ARCHS = {
     'i386': (
-        'https://www.ptgrey.com/support/downloads/10874/',
-        'spinnaker_1_5_0_27_i386',
-        'usr/lib/libSpinnaker.so.1.5.0.27'),
+        'https://www.ptgrey.com/support/downloads/10825/',
+        'spinnaker_1_2_0_16_i386',
+        'usr/lib/libSpinnaker.so.1.2.0.16'),
     'x86_64': (
-        'https://www.ptgrey.com/support/downloads/10875/',
-        'spinnaker_1_5_0_27_amd64',
-        'usr/lib/libSpinnaker.so.1.5.0.27')
+        'https://www.ptgrey.com/support/downloads/10824/',
+        'spinnaker_1_2_0_16_amd64',
+        'usr/lib/libSpinnaker.so.1.2.0.16')
     }
 
 


### PR DESCRIPTION
Reverted to Spinnaker Version 1.2.0.16 to circumvent the proliferation of numerous sockets causing too many files to opened on linux which eventually causes the stereo nodelet to crash.