### PR TITLE
Update exposure_time dynamic reconfigure param

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -101,7 +101,7 @@ gen.add("frame_rate_auto",                       str_t,       SensorLevels.RECON
 
 gen.add("exposure_mode",                         str_t,       SensorLevels.RECONFIGURE_STOP,        "Sets the operation mode of the Exposure (Timed or TriggerWidth).",                                 "Timed")
 gen.add("exposure_auto",                         str_t,       SensorLevels.RECONFIGURE_RUNNING,     "Sets the automatic exposure mode to: 'Off', 'Once' or 'Continuous'",                               "Continuous")
-gen.add("exposure_time",                         double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Exposure time in microseconds when Exposure Mode is Timed.",                                        0.33,                        0.0,     100.0)
+gen.add("exposure_time",                         double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Exposure time in microseconds when Exposure Mode is Timed and Exposure Auto is not Continuous.",                                        100.0,                        0.0,     32754.0)
 
 gen.add("auto_exposure_time_upper_limit",        double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Upper Limit on Shutter Speed.",                                                                     100,                         0.0,     32754)
 gen.add("auto_shutter",                          bool_t,      SensorLevels.RECONFIGURE_RUNNING,     "Refers to the amount of time that the camera's electronic shutter stays open.",                     True)


### PR DESCRIPTION
From the Spinnaker GUI we can see that this value have the 0 .. 32754
range, but it's only used/enabled when exposure auto is not Continuous.

However, although the text box is enabled for exposure auto Off and
Once, it doesn't really pick its value.