### PR TITLE
update to use non deprecated pluginlib macro (#150)

### DIFF
--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -650,5 +650,5 @@ private:
   pointgrey_camera_driver::PointGreyConfig config_;
 };
 
-PLUGINLIB_DECLARE_CLASS(pointgrey_camera_driver, PointGreyCameraNodelet, pointgrey_camera_driver::PointGreyCameraNodelet, nodelet::Nodelet);  // Needed for Nodelet declaration
+PLUGINLIB_EXPORT_CLASS(pointgrey_camera_driver::PointGreyCameraNodelet, nodelet::Nodelet)  // Needed for Nodelet declaration
 }

--- a/pointgrey_camera_driver/src/stereo_nodelet.cpp
+++ b/pointgrey_camera_driver/src/stereo_nodelet.cpp
@@ -379,5 +379,5 @@ private:
   bool do_rectify_; ///< Whether or not to rectify as if part of an image.  Set to false if whole image, and true if in ROI mode.
 };
 
-PLUGINLIB_DECLARE_CLASS(pointgrey_camera_driver, PointGreyStereoCameraNodelet, pointgrey_camera_driver::PointGreyStereoCameraNodelet, nodelet::Nodelet);  // Needed for Nodelet declaration
+PLUGINLIB_EXPORT_CLASS(pointgrey_camera_driver::PointGreyStereoCameraNodelet, nodelet::Nodelet)  // Needed for Nodelet declaration
 }


### PR DESCRIPTION
Cherry pick fix from upstream

Port all pluginlib interactions to then new support macros.
PLUGINLIB_DECLARE_CLASS has been deprecated and needs to be replaced by PLUGINLIB_EXPORT_CLASS

This is in preparation for upgrading pluginlib

@mikepurvis 