### PR TITLE
Rethrow exceptions and remove result/error return

### DIFF
--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -87,38 +87,29 @@ public:
   * Will connect to the camera specified in the setDesiredCamera(std::string id) call.  If setDesiredCamera is not called first
   * this will connect to the first camera.  Connecting to the first camera is not recommended for multi-camera or production systems.
   * This function must be called before setNewConfiguration() or start()!
-  *
-  * \return 0 if no error, -1 if error encountered.
   */
-  int connect();
+  void connect();
 
   /*!
   * \brief Disconnects from the camera.
   *
   * Disconnects the camera and frees it.
-  *
-  * \return 0 if no error, -1 if error encountered.
   */
-  int disconnect();
+  void disconnect();
 
   /*!
   * \brief Starts the camera loading data into its buffer.
   *
   * This function will start the camera capturing images and loading them into the buffer.  To retrieve images, grabImage must be called.
-  *
-  * \return 0 if no error, -1 if error encountered.
   */
-  int start();
+  void start();
 
   /*!
   * \brief Stops the camera loading data into its buffer.
   *
   * This function will stop the camera capturing images and loading them into the buffer.
-  *
-  * \return Returns true if the camera was started when called.  Useful for knowing if the camera needs restarted in certain instances.
   */
-  bool stop();
-
+  void stop();
 
   /*!
   * \brief Loads the raw data from the cameras buffer.
@@ -126,10 +117,8 @@ public:
   * This function will load the raw data from the buffer and place it into a sensor_msgs::Image.
   * \param image sensor_msgs::Image that will be filled with the image currently in the buffer.
   * \param frame_id The name of the optical frame of the camera.
-  *
-  * \return 0 if no error, -1 if error encountered.
   */
-  int grabImage(sensor_msgs::Image &image, const std::string &frame_id);
+  void grabImage(sensor_msgs::Image &image, const std::string &frame_id);
 
   void grabStereoImage(sensor_msgs::Image &image, const std::string &frame_id,
                       sensor_msgs::Image &second_image, const std::string &second_frame_id);
@@ -238,7 +227,7 @@ private:
   // this by enabling each type of chunk data before enabling chunk data mode.
   // When chunk data is turned on, the data is made available in both the nodemap
   // and each image.
-  int ConfigureChunkData(Spinnaker::GenApi::INodeMap & nodeMap);
+  void ConfigureChunkData(Spinnaker::GenApi::INodeMap & nodeMap);
 
   /*!
   * \brief Changes the video mode of the connected camera.

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/camera_exceptions.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/camera_exceptions.h
@@ -38,21 +38,21 @@ class CameraTimeoutException: public std::runtime_error
 {
 public:
   CameraTimeoutException(): runtime_error("Image not found within timeout.") {}
-  CameraTimeoutException(std::string msg): runtime_error(msg.c_str()) {}
+  CameraTimeoutException(const std::string& msg): runtime_error(msg.c_str()) {}
 };
 
 class CameraNotRunningException: public std::runtime_error
 {
 public:
   CameraNotRunningException(): runtime_error("Camera is currently not running.  Please start the capture.") {}
-  CameraNotRunningException(std::string msg): runtime_error(msg.c_str()) {}
+  CameraNotRunningException(const std::string& msg): runtime_error(msg.c_str()) {}
 };
 
 class CameraImageNotReadyException: public std::runtime_error
 {
 public:
   CameraImageNotReadyException(): runtime_error("Image is currently not ready.") {}
-  CameraImageNotReadyException(std::string msg): runtime_error(msg.c_str()) {}
+  CameraImageNotReadyException(const std::string& msg): runtime_error(msg.c_str()) {}
 };
 
 #endif

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -83,7 +83,7 @@ public:
         NODELET_DEBUG_ONCE("Disconnecting from camera.");
         pg_.disconnect();
       }
-      catch(std::runtime_error& e)
+      catch(const std::runtime_error& e)
       {
         NODELET_ERROR_ONCE("%s", e.what());
       }
@@ -378,8 +378,6 @@ private:
   {
     ROS_INFO_ONCE("devicePoll");
 
-    int result = 0;
-
     enum State
     {
         NONE
@@ -456,7 +454,7 @@ private:
           {
             NODELET_DEBUG_ONCE("Connecting to camera.");
 
-            result = pg_.connect();
+            pg_.connect();
 
             NODELET_DEBUG_ONCE("Connected to camera.");
 
@@ -486,7 +484,7 @@ private:
 
             state = CONNECTED;
           }
-          catch(std::runtime_error& e)
+          catch(const std::runtime_error& e)
           {
             if (state_changed)
             {
@@ -522,7 +520,7 @@ private:
             wfov_camera_msgs::WFOVImagePtr wfov_image(new wfov_camera_msgs::WFOVImage);
             // Get the image from the camera library
             NODELET_DEBUG_ONCE("Starting a new grab from camera with serial {%d}.", pg_.getSerial());
-            result = pg_.grabImage(wfov_image->image, frame_id_);
+            pg_.grabImage(wfov_image->image, frame_id_);
 
             // Set other values
             wfov_image->header.frame_id = frame_id_;


### PR DESCRIPTION
fixes CORE-11004

The code in src/nodelet.cpp already catches all exceptions and ignores
the result/error returned by the PointGreyCamera class methods.