### PR TITLE
Migrate the download script to use python3

### DIFF
--- a/pointgrey_camera_driver/cmake/download_spinnaker
+++ b/pointgrey_camera_driver/cmake/download_spinnaker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Software License Agreement (BSD)
 #
@@ -23,15 +23,12 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import cookielib
-import cStringIO
 import logging
 import shutil
 import subprocess
 import sys
 import tarfile
-import urllib
-import urllib2
+import urllib.request
 import os
 
 logging.basicConfig(level=logging.INFO)
@@ -55,7 +52,7 @@ destination_folder = sys.argv[2]
 
 if not os.path.exists(os.path.join(os.getcwd(), "usr/lib/")):
     logging.info("Downloading SDK archive.")
-    urllib.urlretrieve(archive_url, filename)
+    urllib.request.urlretrieve(archive_url, filename)
     logging.info("Unpacking tarball.")
     with tarfile.open(name=filename, mode="r:gz") as tar:
         tar.extractall()


### PR DESCRIPTION
Migrate the script used for downloading the spinnaker tar to python3.

This fails when we do a hard cut over to python3 running as the default.

Ticket: https://jira.clearpathrobotics.com/browse/TOOL-2870

Tested on a local build